### PR TITLE
恢复地图自带尸变比，修正僵尸回血速度

### DIFF
--- a/mapcfg/ze_FFXII_Salikawood_v1_6f.cfg
+++ b/mapcfg/ze_FFXII_Salikawood_v1_6f.cfg
@@ -18,7 +18,7 @@ hook_boss_money_max "30"
 hook_boss_money_min "20"
 hook_boss_enable "1"
 
-zr_infect_mzombie_ratio "7"
+zr_infect_mzombie_ratio "5"
 
 //禁用特殊武器和手雷文字
 sm_xsys_config change xsys.detext.disabled 1
@@ -28,7 +28,7 @@ sm_xsys_config change xsys.items.scan.disabled 1
 entwatch_blockepick 1
 
 zr_class_modify "zombies" "health" "8888"
-zr_class_modify "zombies" "health_regen_amount" "1000"
+zr_class_modify "zombies" "health_regen_amount" "150"
 zr_class_modify "humans" "health_regen_interval" "0"
 zr_class_modify "humans" "health_regen_amount" "0"
 


### PR DESCRIPTION
---
name: 地图参数修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 地图自带尸变比参数，之前回血写多了
2. 修改方式: <!-- 调高僵尸高亮至1500金钱 -->
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图:
+ <!-- ze_serpentis_temple_p2: 整体地图阴暗 -->
+ <!-- ze_3rd_level_is_dark_p1: 第三关阴暗 -->
+ 
