### PR TITLE
奖励时间更新

### DIFF
--- a/mapbouns/ze_castlevania_p1_7.cfg
+++ b/mapbouns/ze_castlevania_p1_7.cfg
@@ -5,7 +5,7 @@
 	{
 		"1"
 		{
-			"round_time_need" "300"
+			"round_time_need" "200"
 			"point" "25"
 		}
 	}


### PR DESCRIPTION
第一关回合时间不达标无法给与奖励更改时间   ，实际时间260都到不了.

---
name: 地图参数修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: <!-- 例子：地图比较阴暗，高亮僵尸将会给人类太大优势 -->
2. 修改方式: <!-- 调高僵尸高亮至1500金钱 -->
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图:
+ <!-- ze_serpentis_temple_p2: 整体地图阴暗 -->
+ <!-- ze_3rd_level_is_dark_p1: 第三关阴暗 -->
+ 
