### PR TITLE
Create ze_parkers_pit_p.cfg

### DIFF
--- a/cs2/counterstrikesharp/configs/map-cfg/ze_parkers_pit_p.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_parkers_pit_p.cfg
@@ -1,1 +1,2 @@
+mp_timelimit 40
 css_hegrenade_limit 6

--- a/cs2/counterstrikesharp/configs/map-cfg/ze_parkers_pit_p.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_parkers_pit_p.cfg
@@ -1,0 +1,1 @@
+css_hegrenade_limit 6


### PR DESCRIPTION
增加默认手雷配置

---
name: 地图参数修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 是


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 按照go1时期6雷2火×0.75修改为6雷配置
2. 修改方式: css_hegrenade_limit 6
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图:ze_parkers_pit_p
