### PR TITLE
配置地图时间，手雷

### DIFF
--- a/cs2/counterstrikesharp/configs/map-cfg/ze_diverted_destiny.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_diverted_destiny.cfg
@@ -1,0 +1,2 @@
+mp_timelimit 40
+css_hegrenade_limit 8

--- a/cs2/counterstrikesharp/configs/map-cfg/ze_diverted_destiny.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_diverted_destiny.cfg
@@ -1,2 +1,3 @@
 mp_timelimit 40
 css_hegrenade_limit 8
+zr_infect_spawn_mz_ratio 7

--- a/cs2/counterstrikesharp/configs/map-text/ze_diverted_destiny.jsonc
+++ b/cs2/counterstrikesharp/configs/map-text/ze_diverted_destiny.jsonc
@@ -1,308 +1,335 @@
 {
-  "Loading Stage 1": {
-    "translation": ""
-  },
-  "Map by KadianS": {
-    "translation": ""
-  },
-  "Problems? Contact me": {
-    "translation": ""
-  },
-  "Have fun!": {
-    "translation": ""
-  },
-  "Zombie Items have been spawned": {
-    "translation": ""
-  },
-  "Zombie Fireball has been picked up": {
-    "translation": ""
-  },
-  "Cooldown: 30 Seconds": {
-    "translation": ""
-  },
-  "Zombie Flight has been picked up": {
-    "translation": ""
-  },
-  "Zombie Heal has been picked up": {
-    "translation": ""
-  },
-  "Cooldown: 30 Seconds | Duration: 5 Seconds": {
-    "translation": ""
-  },
-  "Cooldown: 60 Seconds | Duration: 10 Seconds": {
-    "translation": ""
-  },
-  "Zombie Gravity has been picked up": {
-    "translation": ""
-  },
-  "Cooldown: 90 Seconds | Duration: 5 Seconds": {
-    "translation": ""
+  "...": {
+    "translation": "..."
   },
   "10 Seconds": {
-    "translation": ""
-  },
-  "Flame has been picked up": {
-    "translation": ""
-  },
-  "20 Seconds": {
-    "translation": ""
-  },
-  "60 Seconds CD | 5 Seconds Duration": {
-    "translation": ""
-  },
-  "ZM TP in 10 Seconds": {
-    "translation": ""
-  },
-  "45 Seconds": {
-    "translation": ""
-  },
-  "ZM TP in 15 Seconds": {
-    "translation": ""
-  },
-  "30 Seconds": {
-    "translation": ""
-  },
-  "Doors will close in 10 Seconds": {
-    "translation": ""
-  },
-  "Elevator will break in 5 Seconds": {
-    "translation": ""
-  },
-  "Shortcut will be opened": {
-    "translation": ""
-  },
-  "We can't get passed through that thing yet": {
-    "translation": ""
-  },
-  "We should find a way": {
-    "translation": ""
-  },
-  "Heal has been picked up": {
-    "translation": ""
-  },
-  "60 Seconds CD | 10 Seconds Duration": {
-    "translation": ""
-  },
-  "Right door opens in 20 Seconds": {
-    "translation": ""
-  },
-  "Right door closes in 10 Seconds": {
-    "translation": ""
-  },
-  "Left door opens in 20 Seconds": {
-    "translation": ""
-  },
-  "We got Green and Yellow's power": {
-    "translation": ""
-  },
-  "What do we do now?": {
-    "translation": ""
-  },
-  "...": {
-    "translation": ""
-  },
-  "We got enough power to charge through the courtyard defense": {
-    "translation": ""
-  },
-  "We have to go back though..": {
-    "translation": ""
-  },
-  "We'll have to go back here tomorrow": {
-    "translation": ""
-  },
-  "We'll be more prepared using these two's powers": {
-    "translation": ""
-  },
-  "We don't know where's blue though": {
-    "translation": ""
-  },
-  "Blue's long dead, what did you expect from Red's reign": {
-    "translation": ""
-  },
-  "Blue's long dead, let's just get back.": {
-    "translation": ""
-  },
-  "Let's just get back": {
-    "translation": ""
-  },
-  "[GET OUT]": {
-    "translation": ""
-  },
-  "[NUKE IN 180 SECONDS]": {
-    "translation": ""
-  },
-  "TP in 10 Seconds": {
-    "translation": ""
-  },
-  "Next Stage has been Triggered": {
-    "translation": ""
-  },
-  "Loading Stage 2": {
-    "translation": ""
-  },
-  "Loot points have been depleted": {
-    "translation": ""
-  },
-  "Spawning Hammers": {
-    "translation": ""
-  },
-  "Spawning Loot Points": {
-    "translation": ""
-  },
-  "We're back here": {
-    "translation": ""
-  },
-  "We might be able to go through the courtyard now": {
-    "translation": ""
-  },
-  "Loot Item has been picked up": {
-    "translation": ""
-  },
-  "CD: 5 Seconds": {
-    "translation": ""
-  },
-  "An available loot point has been found": {
-    "translation": ""
-  },
-  "Green Fireball has been picked up": {
-    "translation": ""
-  },
-  "Survive for 60 Seconds": {
-    "translation": ""
-  },
-  "Survive for 30 Seconds": {
-    "translation": ""
-  },
-  "Scourge": {
-    "translation": ""
-  },
-  "Get on a body of water!": {
-    "translation": ""
-  },
-  "Devour": {
-    "translation": ""
-  },
-  "Boss is dead!": {
-    "translation": ""
-  },
-  "Hurry! Get to the entrance!": {
-    "translation": ""
-  },
-  "Elevator will rise in 20 Seconds": {
-    "translation": ""
-  },
-  "It's that thing..": {
-    "translation": ""
-  },
-  "Shoot it!": {
-    "translation": ""
-  },
-  "[Defend yourself while shooting it]": {
-    "translation": ""
-  },
-  "Get away from the elevator!": {
-    "translation": ""
-  },
-  "Shoot it!!": {
-    "translation": ""
-  },
-  "Steam": {
-    "translation": ""
-  },
-  "Absorb": {
-    "translation": ""
-  },
-  "Zombie Attack": {
-    "translation": ""
-  },
-  "Did we kill it..?": {
-    "translation": ""
-  },
-  "Wait, It's about to explode!!": {
-    "translation": ""
-  },
-  "Where are we..?": {
-    "translation": ""
-  },
-  "Look on top, it's blue..?": {
-    "translation": ""
-  },
-  "Quick, no time to waste. Let's find a way to obtain blue's power": {
-    "translation": ""
-  },
-  "Pull four levers around the place to charge blue up": {
-    "translation": ""
-  },
-  "Zombies has been Released": {
-    "translation": ""
-  },
-  "Survive until Blue has been charged up": {
-    "translation": ""
-  },
-  "25%": {
-    "translation": ""
-  },
-  "50%": {
-    "translation": ""
-  },
-  "75%": {
-    "translation": ""
+    "translation": "10 秒"
   },
   "100%": {
-    "translation": ""
+    "translation": "100%"
   },
-  "Fully Charged": {
-    "translation": ""
+  "20 Seconds": {
+    "translation": "20 秒"
   },
-  "Step unto the playform to recieve blue's power.": {
-    "translation": ""
+  "25%": {
+    "translation": "25%"
   },
-  "Water Nymph has been picked up": {
-    "translation": ""
+  "30 Seconds": {
+    "translation": "30 秒"
   },
-  "Survive for 60 more seconds": {
-    "translation": ""
+  "45 Seconds": {
+    "translation": "45 秒"
   },
-  "Water Nymph is now spammable!": {
-    "translation": ""
+  "50%": {
+    "translation": "50%"
   },
-  "Kill it in 60 Seconds": {
-    "translation": ""
+  "60 Seconds CD | 10 Seconds Duration": {
+    "translation": "60 秒 CD | 10 秒持续时间",
+    "DoorCountDown": -1
   },
-  "Cleared!": {
-    "translation": ""
+  "60 Seconds CD | 5 Seconds Duration": {
+    "translation": "60 秒 CD | 5 秒持续时间",
+    "DoorCountDown": -1
   },
-  "Blue's going to contain that thing": {
-    "translation": ""
+  "75%": {
+    "translation": "75%"
   },
-  "We need to get out of here!": {
-    "translation": ""
+  "Absorb": {
+    "translation": "吸收"
   },
-  "Escape is leaving in 30 Seconds": {
-    "translation": ""
-  },
-  "Yellow Fireball has been picked up": {
-    "translation": ""
-  },
-  "Warp Item has been picked up": {
-    "translation": ""
-  },
-  "One time use!": {
-    "translation": ""
+  "An available loot point has been found": {
+    "translation": "已找到可用的战利品点"
   },
   "Blue Fireball has been picked up": {
-    "translation": ""
+    "translation": "已拾取蓝色火球"
+  },
+  "Blue's going to contain that thing": {
+    "translation": "蓝色将收容那个东西"
+  },
+  "Blue's long dead, let's just get back.": {
+    "translation": "蓝色早已消亡，我们赶紧回去吧。"
+  },
+  "Blue's long dead, what did you expect from Red's reign": {
+    "translation": "蓝色早已消亡，你对红色的统治有何期待"
+  },
+  "Boss is dead!": {
+    "translation": "Boss 死了！"
+  },
+  "CD: 5 Seconds": {
+    "translation": "CD：5 秒",
+    "DoorCountDown": -1
+  },
+  "Cleared!": {
+    "translation": "已完成！"
   },
   "Cooldown: 20 Seconds": {
-    "translation": ""
+    "translation": "冷却时间：20 秒",
+    "DoorCountDown": -1
+  },
+  "Cooldown: 30 Seconds": {
+    "translation": "冷却时间：30 秒",
+    "DoorCountDown": -1
   },
   "Cooldown: 45 Seconds | Duration: 5 Seconds": {
-    "translation": ""
+    "translation": "冷却时间：45 秒 | 持续时间：5 秒",
+    "DoorCountDown": -1
+  },
+  "Cooldown: 60 Seconds | Duration: 10 Seconds": {
+    "translation": "冷却时间：60 秒 | 持续时间：10 秒",
+    "DoorCountDown": -1
+  },
+  "Cooldown: 90 Seconds Duration: 10 Seconds": {
+    "translation": "冷却时间：90 秒持续时间：10 秒",
+    "DoorCountDown": -1
+  },
+  "Cooldown: 90 Seconds | Duration: 5 Seconds": {
+    "translation": "冷却时间：90 秒|持续时间：5 秒",
+    "DoorCountDown": -1
+  },
+  "Devour": {
+    "translation": "吞噬"
+  },
+  "Did we kill it..?": {
+    "translation": "我们杀了它吗？"
+  },
+  "Doors will close in 10 Seconds": {
+    "translation": "门将在 10 秒后关闭"
+  },
+  "Elevator will break in 5 Seconds": {
+    "translation": "电梯将在 5 秒后损坏"
+  },
+  "Elevator will rise in 20 Seconds": {
+    "translation": "电梯将在 20 秒后上升"
+  },
+  "Escape is leaving in 30 Seconds": {
+    "translation": "最终逃生将在 30 秒后离开"
+  },
+  "Failed!": {
+    "translation": "失败！"
+  },
+  "Firewall has been picked up": {
+    "translation": "火墙已被拾起"
+  },
+  "Flame has been picked up": {
+    "translation": "火焰已被拾起"
+  },
+  "Fully Charged": {
+    "translation": "能量已满"
+  },
+  "Get away from the elevator!": {
+    "translation": "远离电梯！"
+  },
+  "Get on a body of water!": {
+    "translation": "快泡在水里！"
+  },
+  "Green Fireball has been picked up": {
+    "translation": "绿色火球已被拾起"
+  },
+  "Have fun!": {
+    "translation": "玩得开心！"
+  },
+  "Heal has been picked up": {
+    "translation": "治疗已被拾起"
+  },
+  "Hurry! Get to the entrance!": {
+    "translation": "快点！到达入口！"
+  },
+  "It's that thing..": {
+    "translation": "就是那个东西。。"
+  },
+  "Kill it in 60 Seconds": {
+    "translation": "在 60 秒内杀死它"
+  },
+  "Left door opens in 20 Seconds": {
+    "translation": "左边的门在 20 秒后打开"
+  },
+  "Let's just get back": {
+    "translation": "我们回去吧"
+  },
+  "Loading Stage 1": {
+    "translation": "加载阶段 1"
+  },
+  "Loading Stage 2": {
+    "translation": "加载阶段 2"
+  },
+  "Look on top, it's blue..?": {
+    "translation": "看看上面，它是蓝色的。。？"
+  },
+  "Loot Item has been picked up": {
+    "translation": "战利品已被拾起"
+  },
+  "Loot points have been depleted": {
+    "translation": "战利品点已耗尽"
+  },
+  "Map by KadianS": {
+    "translation": "地图作者：KadianS 翻译：Ayanami♪"
+  },
+  "Maximum amount of loot has been reached!": {
+    "translation": "战利品数量已达到上限！"
+  },
+  "Next Stage has been Triggered": {
+    "translation": "已触发下一阶段"
+  },
+  "One time use!": {
+    "translation": "只能使用一次！"
+  },
+  "Problems? Contact me": {
+    "translation": "有问题？联系我"
+  },
+  "Pull four levers around the place to charge blue up": {
+    "translation": "拉动四周的四个杠杆为蓝色充能"
+  },
+  "Quick, no time to waste. Let's find a way to obtain blue's power": {
+    "translation": "快，不要浪费时间。让我们找到获得蓝色力量的方法"
+  },
+  "Red Fireball has been picked up": {
+    "translation": "红色火球已被拾起"
+  },
+  "Right door closes in 10 Seconds": {
+    "translation": "右门将在 10 秒后关闭"
+  },
+  "Right door opens in 20 Seconds": {
+    "translation": "右门将在 20 秒后打开"
+  },
+  "SHOOT IT!!": {
+    "translation": "射击它！！"
+  },
+  "Scourge": {
+    "translation": "天灾 3s"
+  },
+  "Shoot it!": {
+    "translation": "射击它！"
+  },
+  "Shoot it!!": {
+    "translation": "射击它！！"
+  },
+  "Shortcut will be opened": {
+    "translation": "将打开快捷方式"
+  },
+  "Spawning Hammers": {
+    "translation": "生成锤子"
+  },
+  "Spawning Loot Points": {
+    "translation": "生成战利品点"
+  },
+  "Steam": {
+    "translation": "蒸汽"
+  },
+  "Step unto the playform to recieve blue's power.": {
+    "translation": "踏上中间的板子以接收蓝色力量。"
+  },
+  "Survive for 30 Seconds": {
+    "translation": "存活 30 秒"
+  },
+  "Survive for 60 Seconds": {
+    "translation": "存活 60 秒"
+  },
+  "Survive for 60 more seconds": {
+    "translation": "再存活 60 秒"
+  },
+  "Survive until Blue has been charged up": {
+    "translation": "存活至蓝色充能"
+  },
+  "TP in 10 Seconds": {
+    "translation": "10 秒后 TP"
+  },
+  "Wait, It's about to explode!!": {
+    "translation": "等等，它就要爆炸了！！"
+  },
+  "Warp Item has been picked up": {
+    "translation": "扭曲物品已被拾起"
+  },
+  "Water Nymph has been picked up": {
+    "translation": "水仙子已被拾起"
+  },
+  "Water Nymph is now spammable!": {
+    "translation": "水仙子现在可以频繁使用了！"
+  },
+  "We can't get passed through that thing yet": {
+    "translation": "我们暂时无法穿过那个东西"
+  },
+  "We don't know where's blue though": {
+    "translation": "但我们不知道蓝色在哪里"
+  },
+  "We got Green and Yellow's power": {
+    "translation": "我们得到了绿色和黄色的力量"
+  },
+  "We got enough power to charge through the courtyard defense": {
+    "translation": "我们有足够的力量冲破庭院防御"
+  },
+  "We have to go back though..": {
+    "translation": "但我们得回去了……"
+  },
+  "We might be able to go through the courtyard now": {
+    "translation": "我们现在也许可以穿过庭院了"
+  },
+  "We need to get out of here!": {
+    "translation": "我们需要离开这里！"
+  },
+  "We should find a way": {
+    "translation": "我们应该想办法"
+  },
+  "We'll be more prepared using these two's powers": {
+    "translation": "利用这两种力量，我们会准备得更充分"
+  },
+  "We'll have to go back here tomorrow": {
+    "translation": "我们明天必须回去"
+  },
+  "We're back here": {
+    "translation": "我们回来了"
+  },
+  "What do we do now?": {
+    "translation": "我们现在做什么？"
+  },
+  "Where are we..?": {
+    "translation": "我们在哪……？"
+  },
+  "Yellow Fireball has been picked up": {
+    "translation": "黄色火球已被拾起"
   },
   "ZM Flight item has been used.": {
-    "translation": ""
+    "translation": "ZM 飞行已被使用。"
   },
   "ZM Flight item is READY": {
-    "translation": ""
+    "translation": "ZM 飞行已准备就绪"
+  },
+  "ZM TP in 10 Seconds": {
+    "translation": " 10 秒后ZM TP"
+  },
+  "ZM TP in 10 seconds": {
+    "translation": "10 秒后ZM TP"
+  },
+  "ZM TP in 15 Seconds": {
+    "translation": "15 秒后ZM TP"
+  },
+  "Zombie Attack": {
+    "translation": "僵尸进攻"
+  },
+  "Zombie Fireball has been picked up": {
+    "translation": "已拾取僵尸火球"
+  },
+  "Zombie Flight has been picked up": {
+    "translation": "已拾取僵尸飞行"
+  },
+  "Zombie Gravity has been picked up": {
+    "translation": "已拾取僵尸重力"
+  },
+  "Zombie Heal has been picked up": {
+    "translation": "已拾取僵尸治疗"
+  },
+  "Zombie Items have been spawned": {
+    "translation": "已生成僵尸神器"
+  },
+  "Zombies has been Released": {
+    "translation": "已释放僵尸"
+  },
+  "[Defend yourself while shooting it]": {
+    "translation": "[射击时保护自己]"
+  },
+  "[GET OUT]": {
+    "translation": "[撤退]"
+  },
+  "[NUKE IN 180 SECONDS]": {
+    "translation": "[180 秒后触发核弹]"
   }
 }


### PR DESCRIPTION
---
name: 地图参数修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 是


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 地图第一关10+分钟，第二关25+分钟 默认地图时长不足，长征图手雷过少
2. 修改方式: 添加手雷和地图时长
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图:
ze_diverted_destiny
