### PR TITLE
Raise the price of grenades

### DIFF
--- a/cs2/counterstrikesharp/configs/weapons_buyCommand/weapons.json
+++ b/cs2/counterstrikesharp/configs/weapons_buyCommand/weapons.json
@@ -318,7 +318,7 @@
         "DefIndex": 44,
         "Name": "High Explosive Grenade",
         "WeaponName": "weapon_hegrenade",
-        "Price": 2000,
+        "Price": 3000,
         "Command": "he",
         "Slot": "3",
         "Enable":true
@@ -327,7 +327,7 @@
         "DefIndex": 46,
         "Name": "Molotov",
         "WeaponName": "weapon_molotov",
-        "Price": 2500,
+        "Price": 5000,
         "Command": "mov;fire",
         "Slot": "3",
         "Enable":true

--- a/cs2/counterstrikesharp/configs/weapons_buyCommand/weapons.json
+++ b/cs2/counterstrikesharp/configs/weapons_buyCommand/weapons.json
@@ -318,7 +318,7 @@
         "DefIndex": 44,
         "Name": "High Explosive Grenade",
         "WeaponName": "weapon_hegrenade",
-        "Price": 3000,
+        "Price": 2000,
         "Command": "he",
         "Slot": "3",
         "Enable":true


### PR DESCRIPTION
提高手雷价格2000→3000
提高火瓶价格2500→5000（提前做改动

---
name: 地图参数修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 是


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 提高手雷价格以驱使人类开火获得金钱
2. 修改方式: 手雷价格2000→3000 火瓶2500→5000
3. 备用修改方式: 
4. 涉及地图:
