### PR TITLE
启用寂静岭黑血，添加寂静岭关键词搜索

### DIFF
--- a/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
+++ b/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
@@ -1377,7 +1377,7 @@
 	"ze_silent_hill_blackblood_XYY"
 	{
 		"workshop_id"		"3267382742"
-		"enabled"		"1"
+		"enabled"		"0"
 		"filename"		"ze_silent_blackblood"
 		"updatedname"		"ze_silent_hill_blackblood_XYY"
 		"search"		"寂静岭;黑血;silent"

--- a/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
+++ b/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
@@ -1377,9 +1377,10 @@
 	"ze_silent_hill_blackblood_XYY"
 	{
 		"workshop_id"		"3267382742"
-		"enabled"		"0"
+		"enabled"		"1"
 		"filename"		"ze_silent_blackblood"
 		"updatedname"		"ze_silent_hill_blackblood_XYY"
+		"search"		"寂静岭;黑血;silent"
 	}
 	"ze_trainescape_p"
 	{
@@ -1487,6 +1488,7 @@
 		"enabled"		"1"
 		"filename"		"ze_silent2_illusion"
 		"updatedname"		"ze_silent_hill_2_illusion_XYY"
+		"search"		"寂静岭;幻境;silent"
 	}
 	"ze_ardenweald"
 	{
@@ -1715,6 +1717,7 @@
 		"enabled"		"1"
 		"filename"		"ze_silenthill_pt"
 		"updatedname"		"ze_silenthill_pt"
+		"search"		"寂静岭;PT"
 	}
 	"ze_conflict"
 	{

--- a/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
+++ b/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
@@ -1377,7 +1377,7 @@
 	"ze_silent_hill_blackblood_XYY"
 	{
 		"workshop_id"		"3267382742"
-		"enabled"		"0"
+		"enabled"		"1"
 		"filename"		"ze_silent_blackblood"
 		"updatedname"		"ze_silent_hill_blackblood_XYY"
 		"search"		"寂静岭;黑血;silent"

--- a/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
+++ b/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
@@ -1868,6 +1868,7 @@
 		"enabled"		"1"
 		"filename"		"ze_silent_hill_3_dawn"
 		"updatedname"		"ze_silent_hill_3_dawn"
+		"search"		"寂静岭;黎明"
 	}
 	"ze_silent_hill_3_flee"
 	{
@@ -1875,6 +1876,7 @@
 		"enabled"		"1"
 		"filename"		"ze_silent_hill_3_flee"
 		"updatedname"		"ze_silent_hill_3_flee"
+		"search"		"寂静岭;逃离"
 	}
 	"ze_Industrial_Dejavu"
 	{

--- a/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
+++ b/cs2/counterstrikesharp/configs/plugins/MapChooser/maps.txt
@@ -1714,7 +1714,7 @@
 	"ze_silenthill_pt"
 	{
 		"workshop_id"		"3284621426"
-		"enabled"		"1"
+		"enabled"		"0"
 		"filename"		"ze_silenthill_pt"
 		"updatedname"		"ze_silenthill_pt"
 		"search"		"寂静岭;PT"


### PR DESCRIPTION
---
name: 启用地图
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 是


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 有指挥想在93X带寂静岭黑血，跑图没遇到BUG申请启用该地图，顺便添加了寂静岭的关键词搜索
2. 修改方式: <!-- 调高僵尸高亮至1500金钱 -->
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图:
ze_silent_blackblood
ze_silent2_illusion
ze_silenthill_pt
ze_silent_hill_3_dawn
ze_silent_hill_3_flee