### PR TITLE
恢复安魂曲默认尸变时间

### DIFF
--- a/cs2/counterstrikesharp/configs/map-cfg/ze_requiem_test.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_requiem_test.cfg
@@ -2,6 +2,4 @@ mp_roundtime 60
 mp_timelimit 30
 css_hegrenade_limit 6
 css_health_limit 1
-zr_infect_spawn_time_min 10
-zr_infect_spawn_time_max 10
 zr_infect_spawn_mz_ratio 7

--- a/cs2/counterstrikesharp/configs/map-cfg/ze_skygarden.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_skygarden.cfg
@@ -1,4 +1,5 @@
 mp_timelimit 45
+mp_roundtime 30
 css_hegrenade_limit 10
 css_health_limit 1
 zr_infect_spawn_mz_ratio 7

--- a/cs2/counterstrikesharp/configs/map-cfg/ze_zandalar_forever.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_zandalar_forever.cfg
@@ -1,4 +1,5 @@
 mp_timelimit 30
+mp_roundtime 20
 css_start_money 9000
 css_hegrenade_limit 7
 zr_infect_spawn_mz_ratio 7

--- a/cs2/entwatch/maps/ze_requiem_test.json
+++ b/cs2/entwatch/maps/ze_requiem_test.json
@@ -1,0 +1,56 @@
+[
+	{
+		"Name": "逝者的太刀",	
+		"ShortName": "太刀",
+		"Color": "{default}",
+		"HammerID": 11479,
+		"GlowColor": [255,255,255,255],
+		"FilterID": 0,
+		"FilterValue": "",
+		"BlockPickup": false,
+		"AllowTransfer": true,
+		"ForceDrop": true,
+		"Chat": true,
+		"Hud": true,
+		"TriggerID": 0,
+		"UsePriority": true,
+		"AbilityList": [	
+			{
+				"Name": "Item_Berserkeer_Button",
+				"ButtonID": 11480,
+				"ButtonClass": "func_button",
+				"Chat_Uses": true,
+				"Mode": 2,
+				"MaxUses": 0,
+				"CoolDown": 60
+			}
+		]
+	},
+	{
+		"Name": "虹锥",
+		"ShortName": "墙",
+		"Color": "{default}",
+		"HammerID": 6823,
+		"GlowColor": [255,255,255,255],
+		"FilterID": 0,
+		"FilterValue": "",
+		"BlockPickup": false,
+		"AllowTransfer": true,
+		"ForceDrop": true,	
+		"Chat": true,
+		"Hud": true,
+		"TriggerID": 0,
+		"UsePriority": true,
+		"AbilityList": [	
+			{
+				"Name": "Item_Wall_Button",
+				"ButtonID": 6824,	
+				"ButtonClass": "func_button",	
+				"Chat_Uses": true,
+				"Mode": 2,
+				"MaxUses": 0,
+				"CoolDown": 60
+			}
+		]
+	}
+]


### PR DESCRIPTION
---
name: 地图参数修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 是


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 10秒尸变的情况下第二关出生点要贴门守10秒 并且每局开场都有5秒的黑屋时间
2. 修改方式: 恢复15秒默认尸变
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图:
ze_requiem
