### PR TITLE
开局自选菜单启用M249，添加地图配置

### DIFF
--- a/cs2/counterstrikesharp/configs/map-cfg/ze_celestial_ops.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_celestial_ops.cfg
@@ -1,3 +1,3 @@
-mp_timelimit 25
+mp_timelimit 30
 zr_infect_spawn_mz_ratio 7
-css_hegrenade_limit 10
+css_hegrenade_limit 8

--- a/cs2/counterstrikesharp/configs/map-cfg/ze_celestial_ops.cfg
+++ b/cs2/counterstrikesharp/configs/map-cfg/ze_celestial_ops.cfg
@@ -1,0 +1,3 @@
+mp_timelimit 25
+zr_infect_spawn_mz_ratio 7
+css_hegrenade_limit 10

--- a/cs2/counterstrikesharp/configs/weapons_buyCommand/weapons.json
+++ b/cs2/counterstrikesharp/configs/weapons_buyCommand/weapons.json
@@ -327,7 +327,7 @@
         "Slot": "0",
         "Command": "m249",
         "Enable": true,
-        "GunsMenu": false
+        "GunsMenu": true
     },
     {
         "DefIndex": 28,


### PR DESCRIPTION
---
name: 地图参数修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 是


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 开局拿不到那后面也只会起negev，给喜欢玩M249的朋友一点关爱
2. 修改方式: <!-- 调高僵尸高亮至1500金钱 -->
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图:
+ <!-- ze_serpentis_temple_p2: 整体地图阴暗 -->
+ <!-- ze_3rd_level_is_dark_p1: 第三关阴暗 -->
+ 
