### PR TITLE
Update ze_ffxiv_great_gubal_library.json

### DIFF
--- a/cs2/entwatch/maps/ze_ffxiv_great_gubal_library.json
+++ b/cs2/entwatch/maps/ze_ffxiv_great_gubal_library.json
@@ -15,7 +15,7 @@
     "AbilityList": [
       {
         "Name": "Item_BLM_button",
-        "ButtonID": 15755,
+        "ButtonID": 15763,
         "ButtonClass": "func_button",
         "Filter": "Player_BLM:1",
         "Chat_Uses": true,
@@ -24,7 +24,7 @@
         "CoolDown": 0,
         "Ignore": false,
         "LockItem": false,
-        "MathID": 15763,
+        "MathID": 15755,
         "MathNameFix": false,
         "MathFindSpawned": false,
         "MathDontShowMax": true


### PR DESCRIPTION
修复黑魔法师的触发

---
name: Entwatch ze_ffxiv_great_gubal_library 修改
about: 地图参数修改申请提交
---

<!-- ⚠️⚠️ 请不要删除此模版 ⚠️⚠️ -->
<!-- 在提交参数修改前请仔细阅读修改规则，并确认修改内容是否遵守规则内容 -->
<!-- 🧪 参数修改提交前，请进服务器测试是否合理。如果没有权限，请联系OP或者helper帮忙测试 -->
<!-- ⚖️ 参数调整应该保证游戏平衡，并且如果服务器插件和参数不改变的情况下为“最终版本”。避免多次反复调整。 -->
<!-- 🧺 批量调整请为全部地图单独说明理由 -->
是否阅读了修改规则(是/否): 是


<!-- 📋 请完整填写下方表格📋 -->
<!-- 👁️ 在发布前请点击上方 👁️Preview 预览 -->
<!-- 🚧 请删除尖括号的内容 🚧 -->

1. 改动原因: 黑魔法师技能无法触发 <!-- 例子：地图比较阴暗，高亮僵尸将会给人类太大优势 -->
2. 修改方式: 对调ButtonID 和MathID <!-- 调高僵尸高亮至1500金钱 -->
3. 备用修改方式: <!-- 禁用僵尸高亮 -->
4. 涉及地图: ze_ffxiv_great_gubal_library 
+ <!-- ze_serpentis_temple_p2: 整体地图阴暗 -->
+ <!-- ze_3rd_level_is_dark_p1: 第三关阴暗 -->
+ 
